### PR TITLE
UTC and legend tables

### DIFF
--- a/jsonnet/Makefile
+++ b/jsonnet/Makefile
@@ -2,17 +2,13 @@ JSONNET = https://github.com/google/jsonnet/releases/download/v0.15.0/jsonnet-bi
 BINDIR = bin
 TEMPLATESDIR = templates
 OUTPUTDIR = rendered
-TMPDIR = tmp
-ALLDIRS = $(BINDIR) $(OUTPUTDIR) $(TMPDIR)
+ALLDIRS = $(BINDIR) $(OUTPUTDIR)
 
 # Get all templates at $(TEMPLATESDIR)
 TEMPLATES = $(wildcard $(TEMPLATESDIR)/*.jsonnet)
 
 # Replace $(TEMPLATESDIR)/*.jsonnet by $(OUTPUTDIR)/*.json
 outputs = $(patsubst $(TEMPLATESDIR)/%.jsonnet, $(OUTPUTDIR)/%.json, $(TEMPLATES))
-
-# Replace $(TEMPLATESDIR)/*.jsonnet by $(TMPDIR)/*.jsonnet
-fmtoutputs = $(patsubst $(TEMPLATESDIR)/%.jsonnet, $(TMPDIR)/%.jsonnet, $(TEMPLATES))
 
 all: deps build
 
@@ -21,7 +17,8 @@ deps: $(ALLDIRS) $(TEMPLATESDIR)/grafonnet-lib $(BINDIR)/jsonnet
 $(ALLDIRS):
 	mkdir -p $(ALLDIRS)
 
-format: $(fmtoutputs)
+format:
+	$(BINDIR)/jsonnetfmt -i $(TEMPLATES)
 
 build: deps $(TEMPLATESDIR)/grafonnet-lib $(outputs)
 
@@ -34,13 +31,7 @@ $(TEMPLATESDIR)/grafonnet-lib:
 
 $(BINDIR)/jsonnet:
 	@echo "Downloading jsonnet binary"
-	curl -s -L $(JSONNET) | tar xzf - -C $(BINDIR)
-
-# Format each template and output to $(TMPDIR)
-$(TMPDIR)/%.jsonnet: $(TEMPLATESDIR)/%.jsonnet
-	@echo "Formating template $<"
-	$(BINDIR)/jsonnetfmt $< > $@
-	mv $@ $<
+	curl -s -L $(JSONNET) | tar xz -C $(BINDIR)
 
 # Build each template and output to $(OUTPUTDIR)
 $(OUTPUTDIR)/%.json: $(TEMPLATESDIR)/%.jsonnet

--- a/jsonnet/templates/ocp-performance.jsonnet
+++ b/jsonnet/templates/ocp-performance.jsonnet
@@ -144,14 +144,14 @@ local networkConnections(nodeName) =
     legend_values=true,
     legend_hideEmpty=true,
     legend_hideZero=true,
-    transparent= true,
+    transparent=true,
   )
   {
     fill: 0,
     seriesOverrides: [{
-      alias: 'conntrack_entries'
+      alias: 'conntrack_entries',
     }],
-    yaxes: [{show: true}, {show: false}],
+    yaxes: [{ show: true }, { show: false }],
   }
   .addTarget(
     prometheus.target(
@@ -166,31 +166,29 @@ local networkConnections(nodeName) =
   );
 
 
-local containerCPU(nodeName) =
-  grafana.graphPanel.new(
-    title='Top 10 Container CPU usage: ' + nodeName,
-    datasource='$datasource',
-    format='percent',
-    nullPointMode='null as zero'
-  ).addTarget(
-    prometheus.target(
-      'topk(10, sum(rate(container_cpu_usage_seconds_total{name!="",node=~"' + nodeName + '",namespace!="",namespace=~"$namespace"}[2m])) by (namespace, pod, container)) * 100',
-      legendFormat='{{ namespace }}: {{ pod }}-{{ container }}',
-    )
-  );
+local containerCPU(nodeName) = grafana.graphPanel.new(
+  title='Top 10 Container CPU usage: ' + nodeName,
+  datasource='$datasource',
+  format='percent',
+  nullPointMode='null as zero',
+).addTarget(
+  prometheus.target(
+    'topk(10, sum(rate(container_cpu_usage_seconds_total{name!="",node=~"' + nodeName + '",namespace!="",namespace=~"$namespace"}[2m])) by (namespace, pod, container)) * 100',
+    legendFormat='{{ namespace }}: {{ pod }}-{{ container }}',
+  )
+);
 
-local containerMemory(nodeName) =
-  grafana.graphPanel.new(
-    title='Top 10 Container Memory usage: ' + nodeName,
-    datasource='$datasource',
-    format='bytes',
-    nullPointMode='null as zero',
-  ).addTarget(
-    prometheus.target(
-      'topk(10, sum(rate(container_memory_rss{name!="",node=~"' + nodeName + '",namespace!="",namespace=~"$namespace"}[2m])) by (namespace, pod, container))',
-      legendFormat='{{ namespace }}: {{ pod }}-{{ container }}',
-    )
-  );
+local containerMemory(nodeName) = grafana.graphPanel.new(
+  title='Top 10 Container Memory usage: ' + nodeName,
+  datasource='$datasource',
+  format='bytes',
+  nullPointMode='null as zero',
+).addTarget(
+  prometheus.target(
+    'topk(10, sum(rate(container_memory_rss{name!="",node=~"' + nodeName + '",namespace!="",namespace=~"$namespace"}[2m])) by (namespace, pod, container))',
+    legendFormat='{{ namespace }}: {{ pod }}-{{ container }}',
+  )
+);
 
 
 // Individual panel definitions
@@ -219,6 +217,12 @@ local kubeletCPU = grafana.graphPanel.new(
   title='Top 10 Kubelet CPU usage',
   datasource='$datasource',
   format='percent',
+  legend_values=true,
+  legend_alignAsTable=true,
+  legend_max=true,
+  legend_rightSide=true,
+  legend_sort='max',
+  legend_sortDesc=true,
 ).addTarget(
   prometheus.target(
     'topk(10,rate(process_cpu_seconds_total{service="kubelet",job="kubelet"}[2m]))*100',
@@ -230,6 +234,12 @@ local crioCPU = grafana.graphPanel.new(
   title='Top 10 crio CPU usage',
   datasource='$datasource',
   format='percent',
+  legend_values=true,
+  legend_alignAsTable=true,
+  legend_max=true,
+  legend_rightSide=true,
+  legend_sort='max',
+  legend_sortDesc=true,
 ).addTarget(
   prometheus.target(
     'topk(10,rate(process_cpu_seconds_total{service="kubelet",job="crio"}[2m]))*100',
@@ -239,8 +249,14 @@ local crioCPU = grafana.graphPanel.new(
 
 local kubeletMemory = grafana.graphPanel.new(
   datasource='$datasource',
+  title='Top 10 Kubelet memory usage',
   format='bytes',
-  title='Top 10 Kubelet memory usage'
+  legend_values=true,
+  legend_alignAsTable=true,
+  legend_max=true,
+  legend_rightSide=true,
+  legend_sort='max',
+  legend_sortDesc=true,
 ).addTarget(
   prometheus.target(
     'topk(10,process_resident_memory_bytes{service="kubelet",job="kubelet"})',
@@ -250,8 +266,14 @@ local kubeletMemory = grafana.graphPanel.new(
 
 local crioMemory = grafana.graphPanel.new(
   datasource='$datasource',
+  title='Top 10 crio memory usage',
   format='bytes',
-  title='Top 10  crio memory usage'
+  legend_values=true,
+  legend_alignAsTable=true,
+  legend_max=true,
+  legend_rightSide=true,
+  legend_sort='max',
+  legend_sortDesc=true,
 ).addTarget(
   prometheus.target(
     'topk(10,process_resident_memory_bytes{service="kubelet",job="crio"})',
@@ -385,6 +407,7 @@ grafana.dashboard.new(
   'OpenShift Performance',
   description='Performance dashboard for Red Hat OpenShift',
   time_from='now-1h',
+  timezone='utc',
   refresh='30s',
   editable='true',
 )
@@ -498,20 +521,22 @@ grafana.dashboard.new(
 
 // Dashboard definition
 
-.addPanel(grafana.row.new(title='Monitoring stack', collapse=true)
-          .addPanel(promReplMemUsage, gridPos={ x: 0, y: 1, w: 24, h: 12 })
-          , { gridPos: { x: 0, y: 0, w: 24, h: 1 } })
-
-.addPanel(grafana.row.new(title='Kubelet', collapse=true)
-          .addPanels(
-  [
-    kubeletCPU { gridPos: { x: 0, y: 2, w: 12, h: 8 } },
-    crioCPU { gridPos: { x: 12, y: 2, w: 12, h: 8 } },
-    kubeletMemory { gridPos: { x: 0, y: 2, w: 12, h: 8 } },
-    crioMemory { gridPos: { x: 12, y: 2, w: 12, h: 8 } },
-  ]
+.addPanel(
+  grafana.row.new(title='Monitoring stack', collapse=true)
+  .addPanel(promReplMemUsage, gridPos={ x: 0, y: 1, w: 24, h: 12 })
+  , { gridPos: { x: 0, y: 0, w: 24, h: 1 } }
 )
-          , { gridPos: { x: 0, y: 1, w: 24, h: 1 } })
+
+.addPanel(
+  grafana.row.new(title='Kubelet', collapse=true).addPanels(
+    [
+      kubeletCPU { gridPos: { x: 0, y: 2, w: 12, h: 8 } },
+      crioCPU { gridPos: { x: 12, y: 2, w: 12, h: 8 } },
+      kubeletMemory { gridPos: { x: 0, y: 2, w: 12, h: 8 } },
+      crioMemory { gridPos: { x: 12, y: 2, w: 12, h: 8 } },
+    ]
+  ), { gridPos: { x: 0, y: 1, w: 24, h: 1 } }
+)
 
 
 .addPanel(grafana.row.new(title='Cluster Details', collapse=true).addPanels(
@@ -528,8 +553,7 @@ grafana.dashboard.new(
     top10ContMem { gridPos: { x: 0, y: 24, w: 12, h: 8 } },
     top10ContCPU { gridPos: { x: 12, y: 24, w: 12, h: 8 } },
   ]
-)
-          , { gridPos: { x: 0, y: 1, w: 0, h: 8 } })
+), { gridPos: { x: 0, y: 1, w: 0, h: 8 } })
 
 
 .addPanel(grafana.row.new(title='Master: $_master_node', collapse=true, repeat='_master_node').addPanels(
@@ -561,8 +585,7 @@ grafana.dashboard.new(
   ],
 ), { gridPos: { x: 0, y: 1, w: 0, h: 8 } })
 
-.addPanel(grafana.row.new(title='Infra: $_infra_node', collapse=true, repeat='_infra_node')
-          .addPanels(
+.addPanel(grafana.row.new(title='Infra: $_infra_node', collapse=true, repeat='_infra_node').addPanels(
   [
     nodeCPU('$_infra_node') { gridPos: { x: 0, y: 0, w: 12, h: 8 } },
     nodeMemory('$_infra_node') { gridPos: { x: 12, y: 0, w: 12, h: 8 } },

--- a/jsonnet/templates/pgbench-dashboard.jsonnet
+++ b/jsonnet/templates/pgbench-dashboard.jsonnet
@@ -2,25 +2,25 @@ local grafana = import 'grafonnet-lib/grafonnet/grafana.libsonnet';
 local es = grafana.elasticsearch;
 
 local tps_report = grafana.graphPanel.new(
-  title ='TPS Report',
-  datasource = '$datasource1',
-  format = 'ops',
-  transparent = true,
-  legend_show = false,
-  linewidth = 2
-)
-{
-		yaxes: [{
-			format: 'ops',
-			min: '0',
-			show: true
-		},
-		{
-			format: 'short',
-			show: 'false'
-		}]
-	}
-.addTarget(
+  title='TPS Report',
+  datasource='$datasource1',
+  format='ops',
+  transparent=true,
+  legend_show=false,
+  linewidth=2
+) {
+  yaxes: [
+    {
+      format: 'ops',
+      min: '0',
+      show: true,
+    },
+    {
+      format: 'short',
+      show: 'false',
+    },
+  ],
+}.addTarget(
   es.target(
     query='(user = $user) AND (uuid = $uuid)',
     timeField='timestamp',
@@ -28,12 +28,13 @@ local tps_report = grafana.graphPanel.new(
       field: 'tps',
       id: '1',
       meta: {},
-      pipelineAgg:'select metric',
-      pipelineVariables: [{
+      pipelineAgg: 'select metric',
+      pipelineVariables: [
+        {
           name: 'var1',
-          pipelineAgg: 'select metric'
-      }
-    ],
+          pipelineAgg: 'select metric',
+        },
+      ],
       settings: {},
       type: 'sum',
     }],
@@ -54,19 +55,17 @@ local latency_report = grafana.graphPanel.new(
   title='Latency Report',
   datasource='$datasource1',
   format='ms',
-  transparent= true,
-  legend_show = true,
+  transparent=true,
+  legend_show=true,
 )
-	{
-    type: 'heatmap',
-		yaxes: [],
-		yAxis: {
-			format: 'ms',
-			show: true
-		},
-	}
-
-.addTarget(
+                       {
+  type: 'heatmap',
+  yaxes: [],
+  yAxis: {
+    format: 'ms',
+    show: true,
+  },
+}.addTarget(
   es.target(
     query='(uuid.keyword=$uuid) AND (user.keyword=$user)',
     timeField='timestamp',
@@ -94,11 +93,11 @@ local avg_tps = grafana.graphPanel.new(
   title='Overall Average TPS Per Run',
   datasource='$datasource2',
   format='ops',
-  bars = true,
-  lines = false,
-  transparent= true,
-  legend_show = true,
-  legend_min = true,
+  bars=true,
+  lines=false,
+  transparent=true,
+  legend_show=true,
+  legend_min=true,
   legend_max=true,
   legend_avg=true,
   legend_alignAsTable=true,
@@ -106,20 +105,19 @@ local avg_tps = grafana.graphPanel.new(
   show_xaxis=false,
   x_axis_mode='series',
   x_axis_values='avg',
-)
-	{
-		yaxes: [{
-			format: 'ops',
-			min: '0',
-			show: true
-		},
-		{
-			format: 'short',
-			show: 'false'
-		}]
-	}
-
-.addTarget(
+) {
+  yaxes: [
+    {
+      format: 'ops',
+      min: '0',
+      show: true,
+    },
+    {
+      format: 'short',
+      show: 'false',
+    },
+  ],
+}.addTarget(
   es.target(
     query='(uuid.keyword=$uuid) AND (user.keyword=$user)',
     timeField='timestamp',
@@ -131,27 +129,28 @@ local avg_tps = grafana.graphPanel.new(
       settings: {},
       type: 'avg',
     }],
-    bucketAggs=[{
-      field: 'description.keyword',
-      id: '6',
-      settings: {
-        min_doc_count: 1,
-        order: 'asc',
-        orderBy: '_term',
-        size: '10'
+    bucketAggs=[
+      {
+        field: 'description.keyword',
+        id: '6',
+        settings: {
+          min_doc_count: 1,
+          order: 'asc',
+          orderBy: '_term',
+          size: '10',
+        },
+        type: 'terms',
       },
-      type: 'terms',
-    },
-    {
+      {
         field: 'timestamp',
         id: '4',
         settings: {
-            interval: 'auto',
-            min_doc_count: 0,
-            trimEdges: 0
+          interval: 'auto',
+          min_doc_count: 0,
+          trimEdges: 0,
         },
-        type: 'date_histogram'
-    }
+        type: 'date_histogram',
+      },
     ],
   )
 );
@@ -159,66 +158,67 @@ local avg_tps = grafana.graphPanel.new(
 local results = grafana.tablePanel.new(
   title='Result Summary',
   datasource='$datasource1',
-	transparent=true,
-	styles= [
+  transparent=true,
+  styles=[
     {
       pattern: 'Average latency_ms',
-			alias: "Avg latency",
-			align: 'auto',
+      alias: 'Avg latency',
+      align: 'auto',
       type: 'number',
-			decimals: '2',
+      decimals: '2',
     },
     {
       pattern: 'Average tps',
-			alias: "Avg TPS",
-			align: 'auto',
+      alias: 'Avg TPS',
+      align: 'auto',
       type: 'number',
-			decimals: '2'
+      decimals: '2',
     },
   ],
-)
-	.addTarget(
-		es.target(
-    	query ='(uuid.keyword=$uuid) AND (user.keyword=$user)',
-			timeField ='timestamp',
-			bucketAggs = [
-				{
-					field: 'user.keyword',
-					id: '1',
-					settings: {
-						min_doc_count: 1,
-            order: 'desc',
-            orderBy: '_term',
-            size: '10',
-					},
-					type: 'terms'
-				},
-			],
-			
-			metrics=[
-				{
-					field: 'latency_ms',
-					id: '4',
-					meta: {},
-					settings: {},
-					type: 'avg'
-				},
-				{
-					field: 'tps',
-					id: '20',
-					meta: {},
-					settings: {},
-					type: 'avg'
-				}],
-	)
+).addTarget(
+  es.target(
+    query='(uuid.keyword=$uuid) AND (user.keyword=$user)',
+    timeField='timestamp',
+    bucketAggs=[
+      {
+        field: 'user.keyword',
+        id: '1',
+        settings: {
+          min_doc_count: 1,
+          order: 'desc',
+          orderBy: '_term',
+          size: '10',
+        },
+        type: 'terms',
+      },
+    ],
+
+    metrics=[
+      {
+        field: 'latency_ms',
+        id: '4',
+        meta: {},
+        settings: {},
+        type: 'avg',
+      },
+      {
+        field: 'tps',
+        id: '20',
+        meta: {},
+        settings: {},
+        type: 'avg',
+      },
+    ],
+  )
 );
 
 grafana.dashboard.new(
   'Pgbench - Dashboard',
   description='',
   editable='true',
-  time_from='2019-08-02T14:57:32.460Z',
-  time_to= '2019-08-02T16:32:44.012Z'
+  timezone='utc',
+  time_from='now/y',
+  time_to='now'
 )
 
 .addTemplate(
@@ -235,7 +235,7 @@ grafana.dashboard.new(
     'datasource2',
     'elasticsearch',
     'bull-pgbench-summary',
-    label = 'pgbench-summary datasource'
+    label='pgbench-summary datasource'
   )
 )
 
@@ -246,10 +246,10 @@ grafana.dashboard.new(
     '{"find": "terms", "field": "uuid.keyword"}',
     refresh=2,
   ) {
-      type: 'query',
-      multi: false,
-      includeAll: true,
-    }
+    type: 'query',
+    multi: false,
+    includeAll: true,
+  }
 )
 
 .addTemplate(
@@ -259,10 +259,10 @@ grafana.dashboard.new(
     '{"find": "terms", "field": "user.keyword"}',
     refresh=2,
   ) {
-      type: 'query',
-      multi: false,
-      includeAll: true,
-  	}
+    type: 'query',
+    multi: false,
+    includeAll: true,
+  }
 )
 
 .addAnnotation(
@@ -271,12 +271,12 @@ grafana.dashboard.new(
     '$datasource2',
     iconColor='#5794F2'
   ) {
-      enable: true,
-      type: 'tags',
-      timeField:'run_start_timestamp',
-      textField:'user',
-      tagsField:'description'
-  	}
+    enable: true,
+    type: 'tags',
+    timeField: 'run_start_timestamp',
+    textField: 'user',
+    tagsField: 'description',
+  }
 )
 
 
@@ -286,15 +286,15 @@ grafana.dashboard.new(
     '$datasource2',
     iconColor='#B877D9'
   ) {
-      enable: false,
-    	type: 'tags',
-    	timeField:'sample_start_timestamp',
-    	textField:'user',
-    	tagsField:'description'
-  	}
+    enable: false,
+    type: 'tags',
+    timeField: 'sample_start_timestamp',
+    textField: 'user',
+    tagsField: 'description',
+  }
 )
 
 .addPanel(tps_report, gridPos={ x: 0, y: 0, w: 12, h: 9 })
 .addPanel(latency_report, gridPos={ x: 0, y: 9, w: 12, h: 9 })
 .addPanel(avg_tps, gridPos={ x: 12, y: 0, w: 12, h: 9 })
-.addPanel(results, gridPos={x: 12, y: 9, w: 12, h:9})
+.addPanel(results, gridPos={ x: 12, y: 9, w: 12, h: 9 })

--- a/jsonnet/templates/uperf-perf.jsonnet
+++ b/jsonnet/templates/uperf-perf.jsonnet
@@ -11,19 +11,19 @@ local throughput = grafana.graphPanel.new(
   legend_avg=true,
   legend_alignAsTable=true,
   legend_values=true,
-  transparent= true,
-)
-  {
-    yaxes: [{
+  transparent=true,
+) {
+  yaxes: [
+    {
       format: 'bps',
-      show: 'true'
+      show: 'true',
     },
     {
       format: 'pps',
-      show: 'false'
-    }]
-  }
-.addTarget(
+      show: 'false',
+    },
+  ],
+}.addTarget(
   es.target(
     query='uuid: $uuid AND cluster_name: $cluster_name AND user: $user AND  iteration: $iteration AND remote_ip: $server AND message_size: $message_size AND test_type: $test_type AND protocol: $protocol AND num_threads: $threads',
     timeField='uperf_ts',
@@ -34,8 +34,8 @@ local throughput = grafana.graphPanel.new(
       meta: {},
       settings: {
         script: {
-          inline: '_value * 8'
-        }
+          inline: '_value * 8',
+        },
       },
       transparent: true,
       type: 'sum',
@@ -61,19 +61,19 @@ local operations = grafana.graphPanel.new(
   legend_avg=true,
   legend_alignAsTable=true,
   legend_values=true,
-  transparent= true,
-)
-  {
-    yaxes: [{
+  transparent=true,
+) {
+  yaxes: [
+    {
       format: 'pps',
-      show: 'true'
+      show: 'true',
     },
     {
       format: 'pps',
-      show: 'false'
-    }]
-  }
-.addTarget(
+      show: 'false',
+    },
+  ],
+}.addTarget(
   es.target(
     query='uuid: $uuid AND user: $user AND  iteration: $iteration AND remote_ip: $server AND message_size: $message_size AND test_type: $test_type AND protocol: $protocol AND num_threads: $threads',
     timeField='uperf_ts',
@@ -102,125 +102,125 @@ local operations = grafana.graphPanel.new(
 local results = grafana.tablePanel.new(
   title='UPerf Result Summary',
   datasource='$datasource',
-  transparent= true,
-  styles= [
+  transparent=true,
+  styles=[
     {
       pattern: 'message_size',
       type: 'string',
-      unit: 'Bps'
+      unit: 'Bps',
     },
     {
       decimals: '2',
       pattern: 'Average norm_byte',
       type: 'number',
-      unit: 'bps'
+      unit: 'bps',
     },
     {
       decimals: '0',
       pattern: 'Average norm_ops',
       type: 'number',
-      unit: 'none'
+      unit: 'none',
     },
     {
       decimals: '2',
       pattern: 'Average norm_ltcy',
       type: 'number',
-      unit: 'µs'
+      unit: 'µs',
     },
     {
       alias: 'Sample count',
       decimals: '2',
       pattern: 'Count',
       type: 'number',
-      unit: 'short'
-    }
+      unit: 'short',
+    },
   ],
-)
-.addTarget(
+).addTarget(
   es.target(
     query='uuid: $uuid AND user: $user AND  iteration: $iteration AND remote_ip: $server AND message_size: $message_size AND test_type: $test_type AND protocol: $protocol AND NOT norm_ops:0',
     timeField='uperf_ts',
-    bucketAggs=[{
-              fake: true,
-              field: 'test_type.keyword',
-              id: '3',
-              settings: {
-                min_doc_count: 1,
-                order: 'desc',
-                orderBy: '_term',
-                size: '10',
-              },
-              type: 'terms'
-            },
-            {
-              fake: true,
-              field: 'protocol.keyword',
-              id: '4',
-              settings: {
-                min_doc_count: 1,
-                order: 'desc',
-                orderBy: '_term',
-                size: '10'
-              },
-              type: 'terms'
-            },
-            {
-              fake: true,
-              field: 'num_threads',
-              id: '5',
-              settings: {
-                min_doc_count: 1,
-                order: 'desc',
-                orderBy: '_term',
-                size: '10'
-              },
-              type: 'terms'
-            },
-            {
-              field: 'message_size',
-              id: '2',
-              settings: {
-                min_doc_count: 1,
-                order: 'desc',
-                orderBy: '_term',
-                size: '10'
-              },
-              type: 'terms'
-            }
-          ],
-          metrics=[
-            {
-              field: 'norm_byte',
-              id: '1',
-              inlineScript: '_value * 8',
-              meta: {},
-              settings: {
-                script: {
-                  inline: '_value * 8'
-                }
-              },
-              type: 'avg'
-            },
-            {
-              field: 'norm_ops',
-              id: '6',
-              meta: {},
-              settings: {},
-              type: 'avg'
-            },
-            {
-              field: 'norm_ltcy',
-              id: '7',
-              meta: {},
-              settings: {},
-              type: 'avg'
-            },
-            {
-              field: 'select field',
-              id: '8',
-              type: 'count'
-            }
-          ],
+    bucketAggs=[
+      {
+        fake: true,
+        field: 'test_type.keyword',
+        id: '3',
+        settings: {
+          min_doc_count: 1,
+          order: 'desc',
+          orderBy: '_term',
+          size: '10',
+        },
+        type: 'terms',
+      },
+      {
+        fake: true,
+        field: 'protocol.keyword',
+        id: '4',
+        settings: {
+          min_doc_count: 1,
+          order: 'desc',
+          orderBy: '_term',
+          size: '10',
+        },
+        type: 'terms',
+      },
+      {
+        fake: true,
+        field: 'num_threads',
+        id: '5',
+        settings: {
+          min_doc_count: 1,
+          order: 'desc',
+          orderBy: '_term',
+          size: '10',
+        },
+        type: 'terms',
+      },
+      {
+        field: 'message_size',
+        id: '2',
+        settings: {
+          min_doc_count: 1,
+          order: 'desc',
+          orderBy: '_term',
+          size: '10',
+        },
+        type: 'terms',
+      },
+    ],
+    metrics=[
+      {
+        field: 'norm_byte',
+        id: '1',
+        inlineScript: '_value * 8',
+        meta: {},
+        settings: {
+          script: {
+            inline: '_value * 8',
+          },
+        },
+        type: 'avg',
+      },
+      {
+        field: 'norm_ops',
+        id: '6',
+        meta: {},
+        settings: {},
+        type: 'avg',
+      },
+      {
+        field: 'norm_ltcy',
+        id: '7',
+        meta: {},
+        settings: {},
+        type: 'avg',
+      },
+      {
+        field: 'select field',
+        id: '8',
+        type: 'count',
+      },
+    ],
   )
 );
 
@@ -231,6 +231,7 @@ grafana.dashboard.new(
   'Public - UPerf Results',
   description='',
   tags=['network', 'performance'],
+  timezone='utc',
   time_from='now-1h',
   editable='true',
 )
@@ -365,4 +366,4 @@ grafana.dashboard.new(
 
 .addPanel(throughput, gridPos={ x: 0, y: 0, w: 12, h: 9 })
 .addPanel(operations, gridPos={ x: 12, y: 0, w: 12, h: 9 })
-.addPanel(results, gridPos={x: 0, y: 20, w: 24, h: 18})
+.addPanel(results, gridPos={ x: 0, y: 20, w: 24, h: 18 })

--- a/jsonnet/templates/vegeta-wrapper.jsonnet
+++ b/jsonnet/templates/vegeta-wrapper.jsonnet
@@ -10,21 +10,21 @@ local rps = grafana.graphPanel.new(
   legend_avg=true,
   legend_alignAsTable=true,
   legend_values=true,
-  transparent= true,
+  transparent=true,
   nullPointMode='connected',
-)
-  {
-    yaxes: [{
+) {
+  yaxes: [
+    {
       format: 'reqps',
-      show: 'true'
+      show: 'true',
     },
     {
       format: 'pps',
-      show: 'false'
-    }],
-    fill: 2
-  }
-.addTarget(
+      show: 'false',
+    },
+  ],
+  fill: 2,
+}.addTarget(
   es.target(
     query='uuid: $uuid AND hostname: $hostname AND iteration: $iteration AND targets: "$targets"',
     timeField='timestamp',
@@ -58,21 +58,21 @@ local throughput = grafana.graphPanel.new(
   legend_avg=true,
   legend_alignAsTable=true,
   legend_values=true,
-  transparent= true,
+  transparent=true,
   nullPointMode='connected',
-)
-  {
-    yaxes: [{
+) {
+  yaxes: [
+    {
       format: 'reqps',
-      show: 'true'
+      show: 'true',
     },
     {
       format: 'pps',
-      show: 'false'
-    }],
-    fill: 2
-  }
-.addTarget(
+      show: 'false',
+    },
+  ],
+  fill: 2,
+}.addTarget(
   es.target(
     query='uuid: $uuid AND hostname: $hostname AND iteration: $iteration AND targets: "$targets"',
     timeField='timestamp',
@@ -105,21 +105,21 @@ local latency = grafana.graphPanel.new(
   legend_avg=true,
   legend_alignAsTable=true,
   legend_values=true,
-  transparent= true,
+  transparent=true,
   nullPointMode='connected',
-)
-  {
-    yaxes: [{
+) {
+  yaxes: [
+    {
       format: 'µs',
-      show: 'true'
+      show: 'true',
     },
     {
       format: 'pps',
-      show: 'false'
-    }],
-    fill: 2
-  }
-.addTarget(
+      show: 'false',
+    },
+  ],
+  fill: 2,
+}.addTarget(
   es.target(
     query='uuid: $uuid AND hostname: $hostname AND iteration: $iteration AND targets: "$targets"',
     timeField='timestamp',
@@ -142,8 +142,7 @@ local latency = grafana.graphPanel.new(
       type: 'date_histogram',
     }],
   )
-)
-.addTarget(
+).addTarget(
   es.target(
     query='uuid: $uuid AND hostname: $hostname AND iteration: $iteration AND targets: "$targets"',
     timeField='timestamp',
@@ -171,113 +170,113 @@ local latency = grafana.graphPanel.new(
 local results = grafana.tablePanel.new(
   title='Vegeta Result Summary',
   datasource='$datasource',
-  transparent= true,
-  styles= [
-     {
+  transparent=true,
+  styles=[
+    {
       decimals: '2',
       pattern: 'Average rps',
       type: 'number',
-      unit: 'reqps'
+      unit: 'reqps',
     },
-     {
+    {
       decimals: '2',
       pattern: 'Average throughput',
       type: 'number',
-      unit: 'reqps'
+      unit: 'reqps',
     },
     {
       decimals: '2',
       pattern: 'Average p99_latency',
       type: 'number',
-      unit: 'µs'
+      unit: 'µs',
     },
     {
       decimals: '2',
       pattern: 'Average req_latency',
       type: 'number',
-      unit: 'µs'
+      unit: 'µs',
     },
     {
       decimals: '2',
       pattern: 'Average bytes_in',
       type: 'number',
-      unit: 'bps'
+      unit: 'bps',
     },
     {
       decimals: '2',
       pattern: 'Average bytes_out',
       type: 'number',
-      unit: 'bps'
-    }
+      unit: 'bps',
+    },
   ],
-)
-.addTarget(
+).addTarget(
   es.target(
     query='uuid: $uuid AND hostname: $hostname AND iteration: $iteration AND targets: "$targets"',
     timeField='timestamp',
     bucketAggs=[
-            {
-              fake: true,
-              field: 'targets.keyword',
-              id: '1',
-              settings: {
-                min_doc_count: 1,
-                order: 'desc',
-                orderBy: '_term',
-                size: '10',
-              },
-              type: 'terms'
-            },
-            {
-              field: 'uuid.keyword',
-              id: '2',
-              settings: {
-                min_doc_count: 1,
-                order: 'desc',
-                orderBy: '_term',
-                size: '10',
-              },
-              type: 'terms'
-            }
-          ],
-          metrics=[
-            {
-              field: 'rps',
-              id: '3',
-              type: 'avg'
-            },
-            {
-              field: 'throughput',
-              id: '4',
-              type: 'avg'
-            },
-            {
-              field: 'p99_latency',
-              id: '5',
-              type: 'avg'
-            },
-            {
-              field: 'req_latency',
-              id: '6',
-              type: 'avg'
-            },
-            {
-              field: 'bytes_in',
-              id: '7',
-              type: 'avg'
-            },
-            {
-              field: 'bytes_out',
-              id: '8',
-              type: 'avg'
-            },
-          ],
+      {
+        fake: true,
+        field: 'targets.keyword',
+        id: '1',
+        settings: {
+          min_doc_count: 1,
+          order: 'desc',
+          orderBy: '_term',
+          size: '10',
+        },
+        type: 'terms',
+      },
+      {
+        field: 'uuid.keyword',
+        id: '2',
+        settings: {
+          min_doc_count: 1,
+          order: 'desc',
+          orderBy: '_term',
+          size: '10',
+        },
+        type: 'terms',
+      },
+    ],
+    metrics=[
+      {
+        field: 'rps',
+        id: '3',
+        type: 'avg',
+      },
+      {
+        field: 'throughput',
+        id: '4',
+        type: 'avg',
+      },
+      {
+        field: 'p99_latency',
+        id: '5',
+        type: 'avg',
+      },
+      {
+        field: 'req_latency',
+        id: '6',
+        type: 'avg',
+      },
+      {
+        field: 'bytes_in',
+        id: '7',
+        type: 'avg',
+      },
+      {
+        field: 'bytes_out',
+        id: '8',
+        type: 'avg',
+      },
+    ],
   )
 );
 
 grafana.dashboard.new(
   'Vegeta Results Dashboard',
   description='',
+  timezone='utc',
   time_from='now-24h',
   editable='true',
 )

--- a/jsonnet/templates/ycsb.jsonnet
+++ b/jsonnet/templates/ycsb.jsonnet
@@ -4,24 +4,23 @@ local es = grafana.elasticsearch;
 //Panel definitions
 
 local throughput_overtime = grafana.graphPanel.new(
-  title ='Throughput overtime - Phase = $phase : Operation = $operation',
-  datasource = '$datasource1',
-  format = 'ops',
-  linewidth = 2
-)	
-	{
-		yaxes: [{
-			format: 'ops',
-			show: true
-		},
-		{
-			format: 'short',
-			show: false
-		}],
-		fill: 2
-	}
-
-.addTarget(
+  title='Throughput overtime - Phase = $phase : Operation = $operation',
+  datasource='$datasource1',
+  format='ops',
+  linewidth=2
+) {
+  yaxes: [
+    {
+      format: 'ops',
+      show: true,
+    },
+    {
+      format: 'short',
+      show: false,
+    },
+  ],
+  fill: 2,
+}.addTarget(
   es.target(
     query='(uuid.keyword = $uuid) AND (phase.keyword = $phase) AND (user.keyword=$user) AND (action.keyword=$operation)',
     timeField='timestamp',
@@ -33,54 +32,53 @@ local throughput_overtime = grafana.graphPanel.new(
       type: 'avg',
     }],
     bucketAggs=[
-			{
-				field: 'action.keyword',
-				id: '4',
-				settings: {
-					min_doc_count: 1,
-					order: 'desc',
-					orderBy: '_term',
-					size: '10'
-				},
-				type: 'terms'
-			},
-			{
-				field: 'timestamp',
-				id: '3',
-				settings: {
-					interval: 'auto',
-					min_doc_count: 0,
-					trimEdges: 0
-				},
-				type: 'date_histogram'
-			}
-		],
+      {
+        field: 'action.keyword',
+        id: '4',
+        settings: {
+          min_doc_count: 1,
+          order: 'desc',
+          orderBy: '_term',
+          size: '10',
+        },
+        type: 'terms',
+      },
+      {
+        field: 'timestamp',
+        id: '3',
+        settings: {
+          interval: 'auto',
+          min_doc_count: 0,
+          trimEdges: 0,
+        },
+        type: 'date_histogram',
+      },
+    ],
   )
 );
 
 local phase_average_latency = grafana.graphPanel.new(
-  title ='Phase = $phase :: Latency - 90%tile Reported from YCSB',
-  datasource = '$datasource1',
-  format = 'µs',
-  linewidth = 2,
-	lines = false,
-	points = true,
-	nullPointMode = 'connected',
-	pointradius = 1
-)	
-	{
-		yaxes: [{
-			format: 'µs',
-			show: true
-		},
-		{
-			format: 'short',
-			show: true
-		}],
-		fill: 2
-	}
-
-.addTarget(
+  title='Phase = $phase :: Latency - 90%tile Reported from YCSB',
+  datasource='$datasource1',
+  format='µs',
+  linewidth=2,
+  lines=false,
+  points=true,
+  nullPointMode='connected',
+  pointradius=1
+) {
+  yaxes: [
+    {
+      format: 'µs',
+      show: true,
+    },
+    {
+      format: 'short',
+      show: true,
+    },
+  ],
+  fill: 2,
+}.addTarget(
   es.target(
     query='(uuid.keyword = $uuid) AND (phase.keyword = $phase) AND (user.keyword=$user) AND (action.keyword=$operation)',
     timeField='timestamp',
@@ -92,54 +90,53 @@ local phase_average_latency = grafana.graphPanel.new(
       type: 'avg',
     }],
     bucketAggs=[
-			{
-				field: 'action.keyword',
-				id: '3',
-				settings: {
-					min_doc_count: 1,
-					order: 'desc',
-					orderBy: '_term',
-					size: '10'
-				},
-				type: 'terms'
-			},
-			{
-				field: 'timestamp',
-				id: '2',
-				settings: {
-					interval: 'auto',
-					min_doc_count: 0,
-					trimEdges: 0
-				},
-				type: 'date_histogram'
-			}
-		],
+      {
+        field: 'action.keyword',
+        id: '3',
+        settings: {
+          min_doc_count: 1,
+          order: 'desc',
+          orderBy: '_term',
+          size: '10',
+        },
+        type: 'terms',
+      },
+      {
+        field: 'timestamp',
+        id: '2',
+        settings: {
+          interval: 'auto',
+          min_doc_count: 0,
+          trimEdges: 0,
+        },
+        type: 'date_histogram',
+      },
+    ],
   )
 );
 
 local latency_95 = grafana.graphPanel.new(
-  title ='95th% Latency of each workload per YCSB Operation',
-  datasource = '$datasource2',
-  format = 'µs',
-  legend_show = false,
-  linewidth = 2,
-	bars = true,
-  lines = false,
-	x_axis_mode='series',
+  title='95th% Latency of each workload per YCSB Operation',
+  datasource='$datasource2',
+  format='µs',
+  legend_show=false,
+  linewidth=2,
+  bars=true,
+  lines=false,
+  x_axis_mode='series',
   x_axis_values='total',
-)	
-	{
-		yaxes: [{
-			format: 'µs',
-			show: true
-		},
-		{
-			format: 'short',
-			show: false
-		}]
-	}
-
-.addTarget(
+) {
+  yaxes: [
+    {
+      format: 'µs',
+      show: true,
+    },
+    {
+      format: 'short',
+      show: false,
+    },
+  ],
+}.addTarget(
   es.target(
     query='(uuid.keyword = $uuid) AND (phase.keyword = $phase) AND (user.keyword=$user)',
     timeField='timestamp',
@@ -151,57 +148,56 @@ local latency_95 = grafana.graphPanel.new(
       type: 'avg',
     }],
     bucketAggs=[
-			{
-				field: 'workload_type.keyword',
-				id: '5',
-				settings: {
-					min_doc_count: 1,
-					order: 'desc',
-					orderBy: '_term',
-					size: '10'
-				},
-				type: 'terms'
-			},
-			{
-				field: 'timestamp',
-				id: '3',
-				settings: {
-					interval: 'auto',
-					min_doc_count: 0,
-					trimEdges: 0
-				},
-				type: 'date_histogram'
-			}
-		],
+      {
+        field: 'workload_type.keyword',
+        id: '5',
+        settings: {
+          min_doc_count: 1,
+          order: 'desc',
+          orderBy: '_term',
+          size: '10',
+        },
+        type: 'terms',
+      },
+      {
+        field: 'timestamp',
+        id: '3',
+        settings: {
+          interval: 'auto',
+          min_doc_count: 0,
+          trimEdges: 0,
+        },
+        type: 'date_histogram',
+      },
+    ],
   )
 );
 
 local overall_workload_throughput = grafana.graphPanel.new(
-  title ='Overall Throughput per YCSB Workload',
-  datasource = '$datasource2',
-  format = 'ops',
-	legend_rightSide=true,
-	legend_total=true,
-	legend_alignAsTable=true,
-	legend_values=true,
-  linewidth = 2,
-	bars = true,
-  lines = false,
-	x_axis_mode='series',
+  title='Overall Throughput per YCSB Workload',
+  datasource='$datasource2',
+  format='ops',
+  legend_rightSide=true,
+  legend_total=true,
+  legend_alignAsTable=true,
+  legend_values=true,
+  linewidth=2,
+  bars=true,
+  lines=false,
+  x_axis_mode='series',
   x_axis_values='total',
-)	
-	{
-		yaxes: [{
-			format: 'ops',
-			show: true
-		},
-		{
-			format: 'short',
-			show: false
-		}]
-	}
-
-.addTarget(
+) {
+  yaxes: [
+    {
+      format: 'ops',
+      show: true,
+    },
+    {
+      format: 'short',
+      show: false,
+    },
+  ],
+}.addTarget(
   es.target(
     query='(uuid.keyword = $uuid) AND (phase.keyword = $phase) AND (user.keyword=$user)',
     timeField='timestamp',
@@ -213,42 +209,40 @@ local overall_workload_throughput = grafana.graphPanel.new(
       type: 'sum',
     }],
     bucketAggs=[
-			{
-				field: 'workload_type.keyword',
-				id: '5',
-				settings: {
-					min_doc_count: 1,
-					order: 'desc',
-					orderBy: '_term',
-					size: '10'
-				},
-				type: 'terms'
-			},
-			{
-				field: 'timestamp',
-				id: '3',
-				settings: {
-					interval: 'auto',
-					min_doc_count: 0,
-					trimEdges: 0
-				},
-				type: 'date_histogram'
-			}
-		],
+      {
+        field: 'workload_type.keyword',
+        id: '5',
+        settings: {
+          min_doc_count: 1,
+          order: 'desc',
+          orderBy: '_term',
+          size: '10',
+        },
+        type: 'terms',
+      },
+      {
+        field: 'timestamp',
+        id: '3',
+        settings: {
+          interval: 'auto',
+          min_doc_count: 0,
+          trimEdges: 0,
+        },
+        type: 'date_histogram',
+      },
+    ],
   )
 );
 
 local aggregate_operation_sum = grafana.tablePanel.new(
-  title ='Phase = $phase :: $operation - Count',
-  datasource = '$datasource2',
-)
-
-.addTarget(
+  title='Phase = $phase :: $operation - Count',
+  datasource='$datasource2',
+).addTarget(
   es.target(
     query='(uuid.keyword = $uuid) AND (phase.keyword = $phase) AND (user.keyword=$user)',
     timeField='timestamp',
-    alias = '$operation - Operations',
-		metrics=[{
+    alias='$operation - Operations',
+    metrics=[{
       field: 'data.$operation.Operations',
       id: '1',
       meta: {},
@@ -256,17 +250,18 @@ local aggregate_operation_sum = grafana.tablePanel.new(
       type: 'sum',
     }],
     bucketAggs=[
-			{
-				field: 'workload_type.keyword',
-				id: '3',
-				settings: {
-					min_doc_count: 1,
-					order: 'desc',
-					orderBy: '_term',
-					size: '10'
-				},
-				type: 'terms'
-			}],
+      {
+        field: 'workload_type.keyword',
+        id: '3',
+        settings: {
+          min_doc_count: 1,
+          order: 'desc',
+          orderBy: '_term',
+          size: '10',
+        },
+        type: 'terms',
+      },
+    ],
   )
 );
 
@@ -277,7 +272,8 @@ grafana.dashboard.new(
   description='',
   editable='true',
   time_from='now/y',
-  time_to= 'now'
+  time_to='now',
+  timezone='utc',
 )
 
 .addTemplate(
@@ -285,7 +281,7 @@ grafana.dashboard.new(
     'datasource1',
     'elasticsearch',
     'Prod ES - ripsaw-ycsb-results',
-		label='ycsb-results datasource'
+    label='ycsb-results datasource'
   )
 )
 
@@ -294,7 +290,7 @@ grafana.dashboard.new(
     'datasource2',
     'elasticsearch',
     'Prod ES - ripsaw-ycsb-summary',
-		label='ycsb-summary datasource'
+    label='ycsb-summary datasource'
   )
 )
 
@@ -305,10 +301,10 @@ grafana.dashboard.new(
     '{"find": "terms", "field": "uuid.keyword"}',
     refresh=2,
   ) {
-      type: 'query',
-      multi: false,
-      includeAll: true,
-    }
+    type: 'query',
+    multi: false,
+    includeAll: true,
+  }
 )
 
 .addTemplate(
@@ -318,10 +314,10 @@ grafana.dashboard.new(
     '{"find": "terms", "field": "user.keyword"}',
     refresh=2,
   ) {
-      type: 'query',
-      multi: false,
-      includeAll: true,
-  	}
+    type: 'query',
+    multi: false,
+    includeAll: true,
+  }
 )
 
 .addTemplate(
@@ -330,12 +326,12 @@ grafana.dashboard.new(
     '$datasource2',
     '{"find": "terms", "field": "phase.keyword"}',
     refresh=2,
-		current='run'
+    current='run'
   ) {
-      type: 'query',
-      multi: false,
-      includeAll: true,
-  	}
+    type: 'query',
+    multi: false,
+    includeAll: true,
+  }
 )
 
 .addTemplate(
@@ -345,16 +341,16 @@ grafana.dashboard.new(
     '{"find": "fields", "field": "data.*.Operations"}',
     regex='/data.(.*).Operations/',
     refresh=2,
-		current='READ'
+    current='READ'
   ) {
-      type: 'query',
-      multi: false,
-      includeAll: true,
-  	}
+    type: 'query',
+    multi: false,
+    includeAll: true,
+  }
 )
 
 .addPanel(throughput_overtime, gridPos={ x: 0, y: 0, w: 12, h: 9 })
 .addPanel(phase_average_latency, gridPos={ x: 12, y: 0, w: 12, h: 9 })
 .addPanel(latency_95, gridPos={ x: 0, y: 9, w: 24, h: 6 })
-.addPanel(overall_workload_throughput, gridPos={x: 0, y: 15, w: 16, h:10})
-.addPanel(aggregate_operation_sum, gridPos={x: 16, y: 15, w: 8, h: 10})
+.addPanel(overall_workload_throughput, gridPos={ x: 0, y: 15, w: 16, h: 10 })
+.addPanel(aggregate_operation_sum, gridPos={ x: 16, y: 15, w: 8, h: 10 })


### PR DESCRIPTION
Dashboards timezone are now set to UTC and "legend as table" as been also included for Top 10 Kubelet & CRIO Memory/CPU usage. Templates have been also linted properly.

This is an example of how these panels look like with this update:
![image](https://user-images.githubusercontent.com/4614641/88268675-1f172e00-ccd3-11ea-8b92-f765d96a5ad8.png)
