### PR TITLE
Dashboard fixes

### DIFF
--- a/jsonnet/Makefile
+++ b/jsonnet/Makefile
@@ -10,7 +10,7 @@ TEMPLATES = $(wildcard $(TEMPLATESDIR)/*.jsonnet)
 # Replace $(TEMPLATESDIR)/*.jsonnet by $(OUTPUTDIR)/*.json
 outputs = $(patsubst $(TEMPLATESDIR)/%.jsonnet, $(OUTPUTDIR)/%.json, $(TEMPLATES))
 
-all: deps build
+all: deps format build
 
 deps: $(ALLDIRS) $(TEMPLATESDIR)/grafonnet-lib $(BINDIR)/jsonnet
 

--- a/jsonnet/templates/api-performance-overview.jsonnet
+++ b/jsonnet/templates/api-performance-overview.jsonnet
@@ -8,7 +8,7 @@ local request_duration_99th_quartile = grafana.graphPanel.new(
   datasource='$datasource',
 ).addTarget(
   prometheus.target(
-    'histogram_quantile(0.99, sum(rate(apiserver_request_duration_seconds_bucket{apiserver="$apiserver",instance=~"$instance",resource=~"$resource",subresource!="log",verb!~"WATCH|WATCHLIST|PROXY"}[$interval])) by(verb,le))',
+    'histogram_quantile(0.99, sum(rate(apiserver_request_duration_seconds_bucket{instance=~"$instance",resource=~"$resource",subresource!="log",verb!~"WATCH|WATCHLIST|PROXY"}[$interval])) by(verb,le))',
     legendFormat='{{verb}}',
   )
 );
@@ -24,7 +24,7 @@ local request_rate_by_instance = grafana.graphPanel.new(
   legend_sortDesc=true,
 ).addTarget(
   prometheus.target(
-    'sum(rate(apiserver_request_total{apiserver="$apiserver",instance=~"$instance",resource=~"$resource",code=~"$code",verb=~"$verb"}[$interval])) by(instance)',
+    'sum(rate(apiserver_request_total{instance=~"$instance",resource=~"$resource",code=~"$code",verb=~"$verb"}[$interval])) by(instance)',
     legendFormat='{{instance}}',
   )
 );
@@ -38,9 +38,10 @@ local request_duration_99th_quartile_by_resource = grafana.graphPanel.new(
   legend_rightSide=true,
   legend_sort='max',
   legend_sortDesc=true,
+  nullPointMode='null as zero',
 ).addTarget(
   prometheus.target(
-    'histogram_quantile(0.99, sum(rate(apiserver_request_duration_seconds_bucket{apiserver="$apiserver",instance=~"$instance",resource=~"$resource",subresource!="log",verb!~"WATCH|WATCHLIST|PROXY"}[$interval])) by(resource,le))',
+    'histogram_quantile(0.99, sum(rate(apiserver_request_duration_seconds_bucket{instance=~"$instance",resource=~"$resource",subresource!="log",verb!~"WATCH|WATCHLIST|PROXY"}[$interval])) by(resource,le))',
     legendFormat='{{resource}}',
   )
 );
@@ -54,9 +55,10 @@ local request_rate_by_resource = grafana.graphPanel.new(
   legend_rightSide=true,
   legend_sort='max',
   legend_sortDesc=true,
+  nullPointMode='null as zero',
 ).addTarget(
   prometheus.target(
-    'sum(rate(apiserver_request_total{apiserver="$apiserver",instance=~"$instance",resource=~"$resource",code=~"$code",verb=~"$verb"}[$interval])) by(resource)',
+    'sum(rate(apiserver_request_total{instance=~"$instance",resource=~"$resource",code=~"$code",verb=~"$verb"}[$interval])) by(resource)',
     legendFormat='{{resource}}',
   )
 );
@@ -66,12 +68,12 @@ local request_duration_read_write = grafana.graphPanel.new(
   datasource='$datasource',
 ).addTarget(
   prometheus.target(
-    'histogram_quantile(0.99, sum(rate(apiserver_request_duration_seconds_bucket{apiserver="$apiserver",instance=~"$instance",resource=~"$resource",verb=~"LIST|GET"}[$interval])) by(le))',
+    'histogram_quantile(0.99, sum(rate(apiserver_request_duration_seconds_bucket{instance=~"$instance",resource=~"$resource",verb=~"LIST|GET"}[$interval])) by(le))',
     legendFormat='read',
   )
 ).addTarget(
   prometheus.target(
-    'histogram_quantile(0.99, sum(rate(apiserver_request_duration_seconds_bucket{apiserver="$apiserver",instance=~"$instance",resource=~"$resource",verb=~"POST|PUT|PATCH|UPDATE|DELETE"}[$interval])) by(le))',
+    'histogram_quantile(0.99, sum(rate(apiserver_request_duration_seconds_bucket{instance=~"$instance",resource=~"$resource",verb=~"POST|PUT|PATCH|UPDATE|DELETE"}[$interval])) by(le))',
     legendFormat='write',
   )
 );
@@ -82,12 +84,12 @@ local request_rate_read_write = grafana.graphPanel.new(
   datasource='$datasource',
 ).addTarget(
   prometheus.target(
-    'sum(rate(apiserver_request_total{apiserver="$apiserver",instance=~"$instance",resource=~"$resource",verb=~"LIST|GET"}[$interval]))',
+    'sum(rate(apiserver_request_total{instance=~"$instance",resource=~"$resource",verb=~"LIST|GET"}[$interval]))',
     legendFormat='read',
   )
 ).addTarget(
   prometheus.target(
-    'sum(rate(apiserver_request_total{apiserver="$apiserver",instance=~"$instance",resource=~"$resource",verb=~"POST|PUT|PATCH|UPDATE|DELETE"}[$interval]))',
+    'sum(rate(apiserver_request_total{instance=~"$instance",resource=~"$resource",verb=~"POST|PUT|PATCH|UPDATE|DELETE"}[$interval]))',
     legendFormat='write',
   )
 );
@@ -99,7 +101,7 @@ local requests_dropped_rate = grafana.graphPanel.new(
   description='Number of requests dropped with "Try again later" response',
 ).addTarget(
   prometheus.target(
-    'sum(rate(apiserver_dropped_requests_total{apiserver="$apiserver",instance=~"$instance"}[$interval])) by (requestKind)',
+    'sum(rate(apiserver_dropped_requests_total{instance=~"$instance"}[$interval])) by (requestKind)',
   )
 );
 
@@ -110,7 +112,7 @@ local requests_terminated_rate = grafana.graphPanel.new(
   description='Number of requests which apiserver terminated in self-defense',
 ).addTarget(
   prometheus.target(
-    'sum(rate(apiserver_request_terminations_total{apiserver="$apiserver",instance=~"$instance",resource=~"$resource",code=~"$code"}[$interval])) by(component)',
+    'sum(rate(apiserver_request_terminations_total{instance=~"$instance",resource=~"$resource",code=~"$code"}[$interval])) by(component)',
   )
 );
 
@@ -125,7 +127,7 @@ local requests_status_rate = grafana.graphPanel.new(
   legend_sortDesc=true,
 ).addTarget(
   prometheus.target(
-    'sum(rate(apiserver_request_total{apiserver="$apiserver",instance=~"$instance",resource=~"$resource",verb=~"$verb",code=~"$code"}[$interval])) by(code)',
+    'sum(rate(apiserver_request_total{instance=~"$instance",resource=~"$resource",verb=~"$verb",code=~"$code"}[$interval])) by(code)',
     legendFormat='{{code}}'
   )
 );
@@ -141,7 +143,7 @@ local long_running_requests = grafana.graphPanel.new(
   legend_sortDesc=true,
 ).addTarget(
   prometheus.target(
-    'sum(apiserver_longrunning_gauge{apiserver="$apiserver",instance=~"$instance",resource=~"$resource",verb=~"$verb"}) by(instance)',
+    'sum(apiserver_longrunning_gauge{instance=~"$instance",resource=~"$resource",verb=~"$verb"}) by(instance)',
     legendFormat='{{instance}}'
   )
 );
@@ -157,7 +159,7 @@ local request_in_flight = grafana.graphPanel.new(
   legend_sortDesc=true,
 ).addTarget(
   prometheus.target(
-    'sum(apiserver_current_inflight_requests{apiserver="$apiserver",instance=~"$instance"}) by (instance,requestKind)',
+    'sum(apiserver_current_inflight_requests{instance=~"$instance"}) by (instance,requestKind)',
     legendFormat='{{requestKind}}-{{instance}}',
   )
 );
@@ -168,7 +170,7 @@ local pf_requests_rejected = grafana.graphPanel.new(
   description='Number of requests rejected by API Priority and Fairness system',
 ).addTarget(
   prometheus.target(
-    'sum(rate(apiserver_flowcontrol_rejected_requests_total{apiserver="$apiserver",instance=~"$instance",flowSchema=~"$flowSchema",priorityLevel=~"$priorityLevel"}[$interval])) by (reason)',
+    'sum(rate(apiserver_flowcontrol_rejected_requests_total{instance=~"$instance",flowSchema=~"$flowSchema",priorityLevel=~"$priorityLevel"}[$interval])) by (reason)',
   )
 );
 
@@ -184,7 +186,7 @@ local response_size_99th_quartile = grafana.graphPanel.new(
   legend_sortDesc=true,
 ).addTarget(
   prometheus.target(
-    'histogram_quantile(0.99, sum(rate(apiserver_response_sizes_bucket{apiserver="$apiserver",instance=~"$instance",resource=~"$resource",verb=~"$verb"}[$interval])) by(instance,le))',
+    'histogram_quantile(0.99, sum(rate(apiserver_response_sizes_bucket{instance=~"$instance",resource=~"$resource",verb=~"$verb"}[$interval])) by(instance,le))',
     legendFormat='{{instance}}',
   )
 );
@@ -201,7 +203,7 @@ local pf_request_queue_length = grafana.graphPanel.new(
   legend_sortDesc=true,
 ).addTarget(
   prometheus.target(
-    'histogram_quantile(0.99, sum(rate(apiserver_flowcontrol_request_queue_length_after_enqueue_bucket{apiserver="$apiserver",instance=~"$instance",flowSchema=~"$flowSchema",priorityLevel=~"$priorityLevel"}[$interval])) by(flowSchema, priorityLevel, le))',
+    'histogram_quantile(0.99, sum(rate(apiserver_flowcontrol_request_queue_length_after_enqueue_bucket{instance=~"$instance",flowSchema=~"$flowSchema",priorityLevel=~"$priorityLevel"}[$interval])) by(flowSchema, priorityLevel, le))',
     legendFormat='{{flowSchema}}:{{priorityLevel}}',
   )
 );
@@ -218,7 +220,7 @@ local pf_request_wait_duration_99th_quartile = grafana.graphPanel.new(
   legend_sortDesc=true,
 ).addTarget(
   prometheus.target(
-    'histogram_quantile(0.99, sum(rate(apiserver_flowcontrol_request_wait_duration_seconds_bucket{apiserver="$apiserver",instance=~"$instance",flowSchema=~"$flowSchema",priorityLevel=~"$priorityLevel"}[$interval])) by(flowSchema, priorityLevel, le))',
+    'histogram_quantile(0.99, sum(rate(apiserver_flowcontrol_request_wait_duration_seconds_bucket{instance=~"$instance",flowSchema=~"$flowSchema",priorityLevel=~"$priorityLevel"}[$interval])) by(flowSchema, priorityLevel, le))',
     legendFormat='{{flowSchema}}:{{priorityLevel}}',
   )
 );
@@ -235,7 +237,7 @@ local pf_request_execution_duration = grafana.graphPanel.new(
   legend_sortDesc=true,
 ).addTarget(
   prometheus.target(
-    'histogram_quantile(0.99, sum(rate(apiserver_flowcontrol_request_execution_seconds_bucket{apiserver="$apiserver",instance=~"$instance",flowSchema=~"$flowSchema",priorityLevel=~"$priorityLevel"}[$interval])) by(flowSchema, priorityLevel, le))',
+    'histogram_quantile(0.99, sum(rate(apiserver_flowcontrol_request_execution_seconds_bucket{instance=~"$instance",flowSchema=~"$flowSchema",priorityLevel=~"$priorityLevel"}[$interval])) by(flowSchema, priorityLevel, le))',
     legendFormat='{{flowSchema}}:{{priorityLevel}}',
   )
 );
@@ -252,7 +254,7 @@ local pf_request_dispatch_rate = grafana.graphPanel.new(
   legend_sortDesc=true,
 ).addTarget(
   prometheus.target(
-    'sum(rate(apiserver_flowcontrol_dispatched_requests_total{apiserver="$apiserver",instance=~"$instance",flowSchema=~"$flowSchema",priorityLevel=~"$priorityLevel"}[$interval])) by(flowSchema,priorityLevel)',
+    'sum(rate(apiserver_flowcontrol_dispatched_requests_total{instance=~"$instance",flowSchema=~"$flowSchema",priorityLevel=~"$priorityLevel"}[$interval])) by(flowSchema,priorityLevel)',
     legendFormat='{{flowSchema}}:{{priorityLevel}}',
   )
 );
@@ -263,7 +265,7 @@ local pf_concurrency_limit = grafana.graphPanel.new(
   description='Shared concurrency limit in the API Priority and Fairness system',
 ).addTarget(
   prometheus.target(
-    'sum(apiserver_flowcontrol_request_concurrency_limit{apiserver="$apiserver",instance=~"$instance",priorityLevel=~"$priorityLevel"}) by (priorityLevel)',
+    'sum(apiserver_flowcontrol_request_concurrency_limit{instance=~"$instance",priorityLevel=~"$priorityLevel"}) by (priorityLevel)',
     legendFormat='{{priorityLevel}}'
   )
 );
@@ -280,7 +282,7 @@ local pf_pending_in_queue = grafana.graphPanel.new(
   legend_sortDesc=true,
 ).addTarget(
   prometheus.target(
-    'sum(apiserver_flowcontrol_current_inqueue_requests{apiserver="$apiserver",instance=~"$instance",flowSchema=~"$flowSchema",priorityLevel=~"$priorityLevel"}) by (flowSchema,priorityLevel)',
+    'sum(apiserver_flowcontrol_current_inqueue_requests{instance=~"$instance",flowSchema=~"$flowSchema",priorityLevel=~"$priorityLevel"}) by (flowSchema,priorityLevel)',
     legendFormat='{{flowSchema}}:{{priorityLevel}}',
   )
 );

--- a/jsonnet/templates/api-performance-overview.jsonnet
+++ b/jsonnet/templates/api-performance-overview.jsonnet
@@ -324,6 +324,7 @@ grafana.dashboard.new(
   description='',
   timezone='utc',
   time_from='now-1h',
+  refresh='30s',
   editable='true',
 )
 

--- a/jsonnet/templates/api-performance-overview.jsonnet
+++ b/jsonnet/templates/api-performance-overview.jsonnet
@@ -3,12 +3,20 @@ local prometheus = grafana.prometheus;
 
 //Panel definitions
 
-local request_duration_99th_quartile = grafana.graphPanel.new(
+local request_duration_99th_quantile = grafana.graphPanel.new(
   title='request duration - 99th quantile',
   datasource='$datasource',
+  legend_values=true,
+  legend_alignAsTable=true,
+  legend_current=true,
+  legend_rightSide=true,
+  legend_sort='max',
+  legend_sortDesc=true,
+  nullPointMode='null as zero',
+  legend_hideZero=true,
 ).addTarget(
   prometheus.target(
-    'histogram_quantile(0.99, sum(rate(apiserver_request_duration_seconds_bucket{instance=~"$instance",resource=~"$resource",subresource!="log",verb!~"WATCH|WATCHLIST|PROXY"}[$interval])) by(verb,le))',
+    'histogram_quantile(0.99, sum(rate(apiserver_request_duration_seconds_bucket{apiserver=~"$apiserver",instance=~"$instance",resource=~"$resource",subresource!="log",verb!~"WATCH|WATCHLIST|PROXY"}[$interval])) by(verb,le))',
     legendFormat='{{verb}}',
   )
 );
@@ -22,14 +30,16 @@ local request_rate_by_instance = grafana.graphPanel.new(
   legend_rightSide=true,
   legend_sort='max',
   legend_sortDesc=true,
+  nullPointMode='null as zero',
+  legend_hideZero=true,
 ).addTarget(
   prometheus.target(
-    'sum(rate(apiserver_request_total{instance=~"$instance",resource=~"$resource",code=~"$code",verb=~"$verb"}[$interval])) by(instance)',
+    'sum(rate(apiserver_request_total{apiserver=~"$apiserver",instance=~"$instance",resource=~"$resource",code=~"$code",verb=~"$verb"}[$interval])) by(instance)',
     legendFormat='{{instance}}',
   )
 );
 
-local request_duration_99th_quartile_by_resource = grafana.graphPanel.new(
+local request_duration_99th_quantile_by_resource = grafana.graphPanel.new(
   title='request duration - 99th quantile - by resource',
   datasource='$datasource',
   legend_values=true,
@@ -39,9 +49,10 @@ local request_duration_99th_quartile_by_resource = grafana.graphPanel.new(
   legend_sort='max',
   legend_sortDesc=true,
   nullPointMode='null as zero',
+  legend_hideZero=true,
 ).addTarget(
   prometheus.target(
-    'histogram_quantile(0.99, sum(rate(apiserver_request_duration_seconds_bucket{instance=~"$instance",resource=~"$resource",subresource!="log",verb!~"WATCH|WATCHLIST|PROXY"}[$interval])) by(resource,le))',
+    'histogram_quantile(0.99, sum(rate(apiserver_request_duration_seconds_bucket{apiserver=~"$apiserver",instance=~"$instance",resource=~"$resource",subresource!="log",verb!~"WATCH|WATCHLIST|PROXY"}[$interval])) by(resource,le))',
     legendFormat='{{resource}}',
   )
 );
@@ -56,9 +67,10 @@ local request_rate_by_resource = grafana.graphPanel.new(
   legend_sort='max',
   legend_sortDesc=true,
   nullPointMode='null as zero',
+  legend_hideZero=true,
 ).addTarget(
   prometheus.target(
-    'sum(rate(apiserver_request_total{instance=~"$instance",resource=~"$resource",code=~"$code",verb=~"$verb"}[$interval])) by(resource)',
+    'sum(rate(apiserver_request_total{apiserver=~"$apiserver",instance=~"$instance",resource=~"$resource",code=~"$code",verb=~"$verb"}[$interval])) by(resource)',
     legendFormat='{{resource}}',
   )
 );
@@ -68,12 +80,12 @@ local request_duration_read_write = grafana.graphPanel.new(
   datasource='$datasource',
 ).addTarget(
   prometheus.target(
-    'histogram_quantile(0.99, sum(rate(apiserver_request_duration_seconds_bucket{instance=~"$instance",resource=~"$resource",verb=~"LIST|GET"}[$interval])) by(le))',
+    'histogram_quantile(0.99, sum(rate(apiserver_request_duration_seconds_bucket{apiserver=~"$apiserver",instance=~"$instance",resource=~"$resource",verb=~"LIST|GET"}[$interval])) by(le))',
     legendFormat='read',
   )
 ).addTarget(
   prometheus.target(
-    'histogram_quantile(0.99, sum(rate(apiserver_request_duration_seconds_bucket{instance=~"$instance",resource=~"$resource",verb=~"POST|PUT|PATCH|UPDATE|DELETE"}[$interval])) by(le))',
+    'histogram_quantile(0.99, sum(rate(apiserver_request_duration_seconds_bucket{apiserver=~"$apiserver",instance=~"$instance",resource=~"$resource",verb=~"POST|PUT|PATCH|UPDATE|DELETE"}[$interval])) by(le))',
     legendFormat='write',
   )
 );
@@ -84,12 +96,12 @@ local request_rate_read_write = grafana.graphPanel.new(
   datasource='$datasource',
 ).addTarget(
   prometheus.target(
-    'sum(rate(apiserver_request_total{instance=~"$instance",resource=~"$resource",verb=~"LIST|GET"}[$interval]))',
+    'sum(rate(apiserver_request_total{apiserver=~"$apiserver",instance=~"$instance",resource=~"$resource",verb=~"LIST|GET"}[$interval]))',
     legendFormat='read',
   )
 ).addTarget(
   prometheus.target(
-    'sum(rate(apiserver_request_total{instance=~"$instance",resource=~"$resource",verb=~"POST|PUT|PATCH|UPDATE|DELETE"}[$interval]))',
+    'sum(rate(apiserver_request_total{apiserver=~"$apiserver",instance=~"$instance",resource=~"$resource",verb=~"POST|PUT|PATCH|UPDATE|DELETE"}[$interval]))',
     legendFormat='write',
   )
 );
@@ -125,9 +137,11 @@ local requests_status_rate = grafana.graphPanel.new(
   legend_rightSide=true,
   legend_sort='max',
   legend_sortDesc=true,
+  nullPointMode='null as zero',
+  legend_hideZero=true,
 ).addTarget(
   prometheus.target(
-    'sum(rate(apiserver_request_total{instance=~"$instance",resource=~"$resource",verb=~"$verb",code=~"$code"}[$interval])) by(code)',
+    'sum(rate(apiserver_request_total{apiserver=~"$apiserver",instance=~"$instance",resource=~"$resource",verb=~"$verb",code=~"$code"}[$interval])) by(code)',
     legendFormat='{{code}}'
   )
 );
@@ -141,6 +155,8 @@ local long_running_requests = grafana.graphPanel.new(
   legend_rightSide=true,
   legend_sort='max',
   legend_sortDesc=true,
+  nullPointMode='null as zero',
+  legend_hideZero=true,
 ).addTarget(
   prometheus.target(
     'sum(apiserver_longrunning_gauge{instance=~"$instance",resource=~"$resource",verb=~"$verb"}) by(instance)',
@@ -157,6 +173,8 @@ local request_in_flight = grafana.graphPanel.new(
   legend_rightSide=true,
   legend_sort='max',
   legend_sortDesc=true,
+  nullPointMode='null as zero',
+  legend_hideZero=true,
 ).addTarget(
   prometheus.target(
     'sum(apiserver_current_inflight_requests{instance=~"$instance"}) by (instance,requestKind)',
@@ -184,6 +202,8 @@ local response_size_99th_quartile = grafana.graphPanel.new(
   legend_rightSide=true,
   legend_sort='max',
   legend_sortDesc=true,
+  nullPointMode='null as zero',
+  legend_hideZero=true,
 ).addTarget(
   prometheus.target(
     'histogram_quantile(0.99, sum(rate(apiserver_response_sizes_bucket{instance=~"$instance",resource=~"$resource",verb=~"$verb"}[$interval])) by(instance,le))',
@@ -201,6 +221,8 @@ local pf_request_queue_length = grafana.graphPanel.new(
   legend_rightSide=true,
   legend_sort='max',
   legend_sortDesc=true,
+  nullPointMode='null as zero',
+  legend_hideZero=true,
 ).addTarget(
   prometheus.target(
     'histogram_quantile(0.99, sum(rate(apiserver_flowcontrol_request_queue_length_after_enqueue_bucket{instance=~"$instance",flowSchema=~"$flowSchema",priorityLevel=~"$priorityLevel"}[$interval])) by(flowSchema, priorityLevel, le))',
@@ -218,6 +240,8 @@ local pf_request_wait_duration_99th_quartile = grafana.graphPanel.new(
   legend_rightSide=true,
   legend_sort='max',
   legend_sortDesc=true,
+  nullPointMode='null as zero',
+  legend_hideZero=true,
 ).addTarget(
   prometheus.target(
     'histogram_quantile(0.99, sum(rate(apiserver_flowcontrol_request_wait_duration_seconds_bucket{instance=~"$instance",flowSchema=~"$flowSchema",priorityLevel=~"$priorityLevel"}[$interval])) by(flowSchema, priorityLevel, le))',
@@ -235,6 +259,8 @@ local pf_request_execution_duration = grafana.graphPanel.new(
   legend_rightSide=true,
   legend_sort='max',
   legend_sortDesc=true,
+  nullPointMode='null as zero',
+  legend_hideZero=true,
 ).addTarget(
   prometheus.target(
     'histogram_quantile(0.99, sum(rate(apiserver_flowcontrol_request_execution_seconds_bucket{instance=~"$instance",flowSchema=~"$flowSchema",priorityLevel=~"$priorityLevel"}[$interval])) by(flowSchema, priorityLevel, le))',
@@ -252,6 +278,8 @@ local pf_request_dispatch_rate = grafana.graphPanel.new(
   legend_rightSide=true,
   legend_sort='max',
   legend_sortDesc=true,
+  nullPointMode='null as zero',
+  legend_hideZero=true,
 ).addTarget(
   prometheus.target(
     'sum(rate(apiserver_flowcontrol_dispatched_requests_total{instance=~"$instance",flowSchema=~"$flowSchema",priorityLevel=~"$priorityLevel"}[$interval])) by(flowSchema,priorityLevel)',
@@ -280,6 +308,8 @@ local pf_pending_in_queue = grafana.graphPanel.new(
   legend_rightSide=true,
   legend_sort='max',
   legend_sortDesc=true,
+  nullPointMode='null as zero',
+  legend_hideZero=true,
 ).addTarget(
   prometheus.target(
     'sum(apiserver_flowcontrol_current_inqueue_requests{instance=~"$instance",flowSchema=~"$flowSchema",priorityLevel=~"$priorityLevel"}) by (flowSchema,priorityLevel)',
@@ -424,9 +454,9 @@ grafana.dashboard.new(
   },
 )
 
-.addPanel(request_duration_99th_quartile, gridPos={ x: 0, y: 0, w: 12, h: 8 })
+.addPanel(request_duration_99th_quantile, gridPos={ x: 0, y: 0, w: 12, h: 8 })
 .addPanel(request_rate_by_instance, gridPos={ x: 12, y: 0, w: 12, h: 8 })
-.addPanel(request_duration_99th_quartile_by_resource, gridPos={ x: 0, y: 8, w: 12, h: 8 })
+.addPanel(request_duration_99th_quantile_by_resource, gridPos={ x: 0, y: 8, w: 12, h: 8 })
 .addPanel(request_rate_by_resource, gridPos={ x: 12, y: 8, w: 12, h: 8 })
 .addPanel(request_duration_read_write, gridPos={ x: 0, y: 16, w: 12, h: 8 })
 .addPanel(request_rate_read_write, gridPos={ x: 12, y: 16, w: 12, h: 8 })


### PR DESCRIPTION
Several fixes and improvements:
- Include conntrack and packet drop panel. (They were available, however not included in the dashboard object)
- Fix several API dashboard queries
- Remove API related panels from OCP dashboard. This information is present at the API dashboard
- Optimize some queries and panels
- Remove unused clustername references
- Makefile all target now reformats the templates